### PR TITLE
fix for order matching by leaves qty

### DIFF
--- a/lightmatchingengine/lightmatchingengine.py
+++ b/lightmatchingengine/lightmatchingengine.py
@@ -105,7 +105,6 @@ class LightMatchingEngine(object):
                                     Side.BUY, self.curr_trade_id))
                 
                 # Generate the passive executions
-                index = 0
                 while match_qty > 0:
                     # The order hit
                     hit_order = order_book.asks[best_price][0]
@@ -153,7 +152,6 @@ class LightMatchingEngine(object):
                                     Side.SELL, self.curr_trade_id))
                 
                 # Generate the passive executions
-                index = 0
                 while match_qty > 0:
                     # The order hit
                     hit_order = order_book.bids[best_price][0]
@@ -220,6 +218,7 @@ class LightMatchingEngine(object):
             if price_level[index].order_id == order_id:
                 del price_level[index]
                 break
+            index += 1
         
         if index == price_level_len:
             # Cannot find the order ID. Incorrect side

--- a/lightmatchingengine/lightmatchingengine.py
+++ b/lightmatchingengine/lightmatchingengine.py
@@ -93,7 +93,7 @@ class LightMatchingEngine(object):
             while best_price is not None and \
                   (price == 0.0 or price >= best_price ) and \
                   order.leaves_qty > 0:
-                best_price_qty = sum([ask.qty for ask in order_book.asks[best_price]]) 
+                best_price_qty = sum([ask.leaves_qty for ask in order_book.asks[best_price]])
                 match_qty = min(best_price_qty, order.leaves_qty)
                 assert match_qty > 0, "Match quantity must be larger than zero"
                 
@@ -141,7 +141,7 @@ class LightMatchingEngine(object):
             while best_price is not None and \
                   (price == 0.0 or price <= best_price) and \
                   order.leaves_qty > 0:
-                best_price_qty = sum([bid.qty for bid in order_book.bids[best_price]]) 
+                best_price_qty = sum([bid.leaves_qty for bid in order_book.bids[best_price]])
                 match_qty = min(best_price_qty, order.leaves_qty)
                 assert match_qty > 0, "Match quantity must be larger than zero"
                 


### PR DESCRIPTION
Orders should be matched by `leaves_qty`, otherwise it won't work for partially filled orders. 
Also, the `index` counter must be incremented for cancel.   
